### PR TITLE
Feature popper

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -4,13 +4,6 @@ import './ButtonStyle.scss';
 
 import Dropdown from '../dropdown/Dropdown';
 
-const Example: React.FC = () => (
-  <Dropdown>
-    <Dropdown.ToggleButton hi1="hi1" />
-    <Dropdown.Menu hi2="hi2" />
-  </Dropdown>
-);
-
 export type TTheme = 'danger' | 'warning' | 'success' | 'info' | 'default';
 
 export type TSize = 'lg' | 'md' | 'sm';

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -2,6 +2,15 @@ import React from 'react';
 
 import './ButtonStyle.scss';
 
+import Dropdown from '../dropdown/Dropdown';
+
+const Example: React.FC = () => (
+  <Dropdown>
+    <Dropdown.ToggleButton hi1="hi1" />
+    <Dropdown.Menu hi2="hi2" />
+  </Dropdown>
+);
+
 export type TTheme = 'danger' | 'warning' | 'success' | 'info' | 'default';
 
 export type TSize = 'lg' | 'md' | 'sm';

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -22,7 +22,7 @@ export interface ButtonProps {
   /** children */
   children: React.ReactNode;
   /** click event */
-  onClick?: (event?: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 const Button: React.FC<ButtonProps> = ({

--- a/src/components/dropdown/Dropdown.stories.tsx
+++ b/src/components/dropdown/Dropdown.stories.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+
+import Dropdown, { DropdownProps } from './Dropdown';
+import DropdownItem from './DropdownItem';
+
+export default {
+  title: 'Components/Dropdown',
+  component: Dropdown
+} as Meta;
+
+const Template: Story<DropdownProps> = (args: DropdownProps) => {
+  const { title, children } = args;
+  // return <Dropdown title={title}>{children}</Dropdown>;
+  return (
+    <Dropdown title={title}>
+      <DropdownItem item="hi1" />
+      <DropdownItem item="hi2" />
+      <DropdownItem item="hi3" />
+    </Dropdown>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  title: 'title'
+  // children: (
+  //   <>
+  //     <div>hi1</div>
+  //     <div>hi2</div>
+  //     <div>hi3</div>
+  //   </>
+  // )
+};
+
+// TODO: DropdownItem template 만들기

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -1,48 +1,32 @@
-import React from 'react';
+import React, { useState } from 'react';
+import Button from '../button/Button';
+
+import './DropdownStyle.scss';
 
 export interface DropdownProps {
   /** children */
   children?: React.ReactNode;
+  /** title of dropdown toggle */
+  title?: string;
 }
 
-export interface ToggleButtonProps extends DropdownProps {
-  hi1: string;
-}
+const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
+  const { title, children } = props;
+  const [open, setOpen] = useState<boolean>(false);
+  const handleClick = () => {
+    console.log('click & open is', !open);
+    setOpen(prev => !prev);
+  };
+  return (
+    <div className="muop-dropdown">
+      <Button outline className="muop-dropdown-button" onClick={handleClick}>
+        {title}
+      </Button>
+      <div className={`muop-dropdown-menu ${open ? 'open' : 'close'}`}>
+        {children}
+      </div>
+    </div>
+  );
+};
 
-export interface MenuProps extends DropdownProps {
-  hi2: string;
-}
-
-const ToggleButton: React.FC<ToggleButtonProps> = ({
-  ...props
-}: ToggleButtonProps) => (
-  <div>
-    toggle button {props.hi1} {props.children}
-  </div>
-);
-
-const Menu: React.FC<MenuProps> = ({ ...props }: MenuProps) => (
-  <div>menu {props.hi2}</div>
-);
-
-const Dropdown: React.FC = () => <div>dropdown</div>;
-
-export default Object.assign(Dropdown, {
-  ToggleButton({ ...props }: ToggleButtonProps): JSX.Element {
-    return <ToggleButton hi1={props.hi1} />;
-  },
-  Menu({ ...props }: MenuProps): JSX.Element {
-    return <Menu hi2={props.hi2} />;
-  }
-});
-
-// const DropdownComponent: React.FC = () => <div>menu</div>;
-
-// const Example: React.FC = () => (
-//   <Dropdown>
-//     <Dropdown.ToggleButton hi1="hi1" />
-//     <Dropdown.Menu hi2="hi2" />
-//   </Dropdown>
-// );
-
-// export default Dropdown;
+export default Dropdown;

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+export interface DropdownProps {
+  /** children */
+  children?: React.ReactNode;
+}
+
+export interface ToggleButtonProps extends DropdownProps {
+  hi1: string;
+}
+
+export interface MenuProps extends DropdownProps {
+  hi2: string;
+}
+
+const ToggleButton: React.FC<ToggleButtonProps> = ({
+  ...props
+}: ToggleButtonProps) => (
+  <div>
+    toggle button {props.hi1} {props.children}
+  </div>
+);
+
+const Menu: React.FC<MenuProps> = ({ ...props }: MenuProps) => (
+  <div>menu {props.hi2}</div>
+);
+
+const Dropdown: React.FC = () => <div>dropdown</div>;
+
+export default Object.assign(Dropdown, {
+  ToggleButton({ ...props }: ToggleButtonProps): JSX.Element {
+    return <ToggleButton hi1={props.hi1} />;
+  },
+  Menu({ ...props }: MenuProps): JSX.Element {
+    return <Menu hi2={props.hi2} />;
+  }
+});
+
+// const DropdownComponent: React.FC = () => <div>menu</div>;
+
+// const Example: React.FC = () => (
+//   <Dropdown>
+//     <Dropdown.ToggleButton hi1="hi1" />
+//     <Dropdown.Menu hi2="hi2" />
+//   </Dropdown>
+// );
+
+// export default Dropdown;

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Button from '../button/Button';
+import Popper from '../popper/Popper';
 
 import './DropdownStyle.scss';
 
@@ -10,21 +11,25 @@ export interface DropdownProps {
   title?: string;
 }
 
-const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
-  const { title, children } = props;
+const Dropdown: React.FC<DropdownProps> = ({
+  title,
+  children
+}: DropdownProps) => {
+  const anchorRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState<boolean>(false);
   const handleClick = () => {
-    console.log('click & open is', !open);
     setOpen(prev => !prev);
   };
   return (
     <div className="muop-dropdown">
-      <Button outline className="muop-dropdown-button" onClick={handleClick}>
-        {title}
-      </Button>
-      <div className={`muop-dropdown-menu ${open ? 'open' : 'close'}`}>
-        {children}
+      <div ref={anchorRef} style={{ display: 'inline-block' }}>
+        <Button outline className="muop-dropdown-button" onClick={handleClick}>
+          {title}
+        </Button>
       </div>
+      <Popper anchorEl={anchorRef.current} open={open} placement="bottom-start">
+        <div style={{ border: '1px solid gray' }}>{children}</div>
+      </Popper>
     </div>
   );
 };

--- a/src/components/dropdown/DropdownItem.tsx
+++ b/src/components/dropdown/DropdownItem.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export interface DropdownItemProps {
+  item: string;
+}
+
+const DropdownItem: React.FC<DropdownItemProps> = (
+  props: DropdownItemProps
+) => {
+  const { item } = props;
+
+  return <div>{item}</div>;
+};
+export default DropdownItem;

--- a/src/components/dropdown/DropdownStyle.scss
+++ b/src/components/dropdown/DropdownStyle.scss
@@ -1,0 +1,23 @@
+@import '../../index.scss';
+
+.muop-dropdown {
+  &-button {
+    margin-bottom: 8px;
+  }
+
+  &-menu {
+    width: 8rem;
+    border: 1px solid $bd-color-default;
+    border-radius: 0.25rem;
+
+    &.open {
+      display: block;
+      height: auto;
+    }
+
+    &.close {
+      display: none;
+      height: 0;
+    }
+  }
+}

--- a/src/components/popper/Popper.stories.tsx
+++ b/src/components/popper/Popper.stories.tsx
@@ -11,18 +11,15 @@ export default {
   component: Popper
 } as Meta;
 
-const Template: Story<PopperProps> = (args: PopperProps) => {
+const Template: Story<PopperProps> = () => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
   const [open, setOpen] = useState<boolean>(false);
   const [placement, setPlacement] = React.useState<TPlacement>();
 
-  // 이렇게 쓰면 onClick={(e) => handleClick(e, 'top-start')}
-  // const handleClick = (event: React.MouseEvent<HTMLButtonElement>, newPlacement: TPlacement) => {
-  // 이렇게 쓰면 onClick={handleClick('top-start')} -> 나는 이게 더 좋음!
   const handleClick = (newPlacement: TPlacement) => (
-    event: React.MouseEvent<HTMLButtonElement>
+    e: React.MouseEvent<HTMLButtonElement>
   ) => {
-    setAnchorEl(event.currentTarget);
+    setAnchorEl(e.currentTarget);
     setOpen(prev => placement !== newPlacement || !prev);
     setPlacement(newPlacement);
   };

--- a/src/components/popper/Popper.stories.tsx
+++ b/src/components/popper/Popper.stories.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react';
+
+import Popper, { PopperProps, TPlacement } from './Popper';
+import Button from '../button/Button';
+
+import './PopperStyle.scss';
+
+export default {
+  title: 'Components/Popper',
+  component: Popper
+} as Meta;
+
+const Template: Story<PopperProps> = (args: PopperProps) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const [open, setOpen] = useState<boolean>(false);
+  const [placement, setPlacement] = React.useState<TPlacement>();
+
+  // 이렇게 쓰면 onClick={(e) => handleClick(e, 'top-start')}
+  // const handleClick = (event: React.MouseEvent<HTMLButtonElement>, newPlacement: TPlacement) => {
+  // 이렇게 쓰면 onClick={handleClick('top-start')} -> 나는 이게 더 좋음!
+  const handleClick = (newPlacement: TPlacement) => (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    setAnchorEl(event.currentTarget);
+    setOpen(prev => placement !== newPlacement || !prev);
+    setPlacement(newPlacement);
+  };
+
+  return (
+    <div className="popper-story">
+      <Popper anchorEl={anchorEl} open={open} placement={placement}>
+        <div style={{ border: '1px solid gray' }}>I am Popper</div>
+      </Popper>
+      <div className="popper-story-top">
+        <Button outline onClick={handleClick(TPlacement.topStart)}>
+          {TPlacement.topStart}
+        </Button>
+        <Button outline onClick={handleClick(TPlacement.top)}>
+          {TPlacement.top}
+        </Button>
+        <Button outline onClick={handleClick(TPlacement.topEnd)}>
+          {TPlacement.topEnd}
+        </Button>
+      </div>
+      <div className="popper-story-side">
+        <div className="popper-story-side-left">
+          <Button outline onClick={handleClick(TPlacement.leftStart)}>
+            {TPlacement.leftStart}
+          </Button>
+          <Button outline onClick={handleClick(TPlacement.left)}>
+            {TPlacement.left}
+          </Button>
+          <Button outline onClick={handleClick(TPlacement.leftEnd)}>
+            {TPlacement.leftEnd}
+          </Button>
+        </div>
+        <div className="popper-story-side-right">
+          <Button outline onClick={handleClick(TPlacement.rightStart)}>
+            {TPlacement.rightStart}
+          </Button>
+          <Button outline onClick={handleClick(TPlacement.right)}>
+            {TPlacement.right}
+          </Button>
+          <Button outline onClick={handleClick(TPlacement.rightEnd)}>
+            {TPlacement.rightEnd}
+          </Button>
+        </div>
+      </div>
+      <div className="popper-story-bottom">
+        <Button outline onClick={handleClick(TPlacement.bottomStart)}>
+          {TPlacement.bottomStart}
+        </Button>
+        <Button outline onClick={handleClick(TPlacement.bottom)}>
+          {TPlacement.bottom}
+        </Button>
+        <Button outline onClick={handleClick(TPlacement.bottomEnd)}>
+          {TPlacement.bottomEnd}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export const Default = Template.bind({});

--- a/src/components/popper/Popper.tsx
+++ b/src/components/popper/Popper.tsx
@@ -87,7 +87,7 @@ const Popper: React.FC<PopperProps> = ({
           break;
       }
     }
-  }, [anchorEl, placement]);
+  }, [anchorEl, placement, open]);
   return open
     ? ReactDOM.createPortal(
         <div className="muop-popper" role="tooltip" ref={ref}>

--- a/src/components/popper/Popper.tsx
+++ b/src/components/popper/Popper.tsx
@@ -17,7 +17,7 @@ const TPlacement = {
 };
 type TPlacement = typeof TPlacement[keyof typeof TPlacement];
 
-interface PopperProps extends React.HTMLAttributes<HTMLFormElement> {
+interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
   anchorEl: HTMLElement | null;
   placement?: TPlacement;
   open: boolean;
@@ -88,7 +88,6 @@ const Popper: React.FC<PopperProps> = ({
     ? ReactDOM.createPortal(
         <div
           role="tooltip"
-          x-placement="bottom"
           style={{
             position: 'absolute',
             willChange: 'transform',

--- a/src/components/popper/Popper.tsx
+++ b/src/components/popper/Popper.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+
+type TPlacement = 'bottom-start' | 'bottom' | 'bottom-end';
+
+export interface PopperProps extends React.HTMLAttributes<HTMLFormElement> {
+  anchorEl: HTMLElement | null;
+  placement?: TPlacement;
+  open: boolean;
+}
+
+const Popper: React.FC<PopperProps> = ({
+  anchorEl,
+  placement = 'bottom',
+  open,
+  children
+}: PopperProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (ref && ref.current && anchorEl) {
+      const { top, bottom, left, right } = anchorEl.getBoundingClientRect();
+      const center = (right + left) / 2;
+
+      switch (placement) {
+        case 'bottom-start':
+          ref.current.style.transform = `translate(${left}px, ${bottom}px)`;
+          break;
+        case 'bottom':
+          ref.current.style.transform = `translate(${center}px, ${bottom}px)`;
+          break;
+        case 'bottom-end':
+          ref.current.style.transform = `translate(${right}px, ${bottom}px)`;
+          break;
+        default:
+          break;
+      }
+    }
+  }, [anchorEl, placement, open]);
+  return open
+    ? ReactDOM.createPortal(
+        <div
+          role="tooltip"
+          x-placement="bottom"
+          style={{
+            position: 'absolute',
+            willChange: 'transform',
+            top: '0px',
+            left: '0px'
+          }}
+          ref={ref}
+        >
+          {children}
+        </div>,
+        document.getElementById('root')
+      )
+    : null;
+};
+
+export default Popper;

--- a/src/components/popper/Popper.tsx
+++ b/src/components/popper/Popper.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 
+import './PopperStyle.scss';
+
 const TPlacement = {
   bottomStart: 'bottom-start',
   bottom: 'bottom',
@@ -32,6 +34,8 @@ const Popper: React.FC<PopperProps> = ({
   const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (ref && ref.current && anchorEl) {
+      ref.current.style.display = 'block';
+
       const { top, bottom, left, right } = anchorEl.getBoundingClientRect();
       const horiCenter = (right + left) / 2;
       const vertiCenter = (top + bottom) / 2;
@@ -83,19 +87,10 @@ const Popper: React.FC<PopperProps> = ({
           break;
       }
     }
-  }, [anchorEl, placement, open]);
+  }, [anchorEl, placement]);
   return open
     ? ReactDOM.createPortal(
-        <div
-          role="tooltip"
-          style={{
-            position: 'absolute',
-            willChange: 'transform',
-            top: '0px',
-            left: '0px'
-          }}
-          ref={ref}
-        >
+        <div className="muop-popper" role="tooltip" ref={ref}>
           {children}
         </div>,
         document.getElementById('root')!

--- a/src/components/popper/Popper.tsx
+++ b/src/components/popper/Popper.tsx
@@ -1,9 +1,23 @@
 import React, { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 
-type TPlacement = 'bottom-start' | 'bottom' | 'bottom-end';
+const TPlacement = {
+  bottomStart: 'bottom-start',
+  bottom: 'bottom',
+  bottomEnd: 'bottom-end',
+  topStart: 'top-start',
+  top: 'top',
+  topEnd: 'top-end',
+  leftStart: 'left-start',
+  left: 'left',
+  leftEnd: 'left-end',
+  rightStart: 'right-start',
+  right: 'right',
+  rightEnd: 'right-end'
+};
+type TPlacement = typeof TPlacement[keyof typeof TPlacement];
 
-export interface PopperProps extends React.HTMLAttributes<HTMLFormElement> {
+interface PopperProps extends React.HTMLAttributes<HTMLFormElement> {
   anchorEl: HTMLElement | null;
   placement?: TPlacement;
   open: boolean;
@@ -19,16 +33,50 @@ const Popper: React.FC<PopperProps> = ({
   useEffect(() => {
     if (ref && ref.current && anchorEl) {
       const { top, bottom, left, right } = anchorEl.getBoundingClientRect();
-      const center = (right + left) / 2;
+      const horiCenter = (right + left) / 2;
+      const vertiCenter = (top + bottom) / 2;
+      const childTop = top - ref.current.getBoundingClientRect().height;
+      const childLeft = left - ref.current.getBoundingClientRect().width;
 
       switch (placement) {
+        // top
+        case 'top-start':
+          ref.current.style.transform = `translate(${left}px, ${childTop}px)`;
+          break;
+        case 'top':
+          ref.current.style.transform = `translate(${horiCenter}px, ${childTop}px)`;
+          break;
+        case 'top-end':
+          ref.current.style.transform = `translate(${right}px, ${childTop}px)`;
+          break;
+        // bottom
         case 'bottom-start':
           ref.current.style.transform = `translate(${left}px, ${bottom}px)`;
           break;
         case 'bottom':
-          ref.current.style.transform = `translate(${center}px, ${bottom}px)`;
+          ref.current.style.transform = `translate(${horiCenter}px, ${bottom}px)`;
           break;
         case 'bottom-end':
+          ref.current.style.transform = `translate(${right}px, ${bottom}px)`;
+          break;
+        // left
+        case 'left-start':
+          ref.current.style.transform = `translate(${childLeft}px, ${top}px)`;
+          break;
+        case 'left':
+          ref.current.style.transform = `translate(${childLeft}px, ${vertiCenter}px)`;
+          break;
+        case 'left-end':
+          ref.current.style.transform = `translate(${childLeft}px, ${bottom}px)`;
+          break;
+        // right
+        case 'right-start':
+          ref.current.style.transform = `translate(${right}px, ${top}px)`;
+          break;
+        case 'right':
+          ref.current.style.transform = `translate(${right}px, ${vertiCenter}px)`;
+          break;
+        case 'right-end':
           ref.current.style.transform = `translate(${right}px, ${bottom}px)`;
           break;
         default:
@@ -51,9 +99,10 @@ const Popper: React.FC<PopperProps> = ({
         >
           {children}
         </div>,
-        document.getElementById('root')
+        document.getElementById('root')!
       )
     : null;
 };
 
+export { TPlacement, PopperProps };
 export default Popper;

--- a/src/components/popper/PopperStyle.scss
+++ b/src/components/popper/PopperStyle.scss
@@ -1,37 +1,35 @@
+@import '../../index.scss';
+
+@mixin btn-margin {
+  button + button {
+    margin-left: 0;
+  }
+  button {
+    margin-bottom: 4px;
+  }
+}
+
 .popper-story {
   padding: 50px;
 
   &-top {
-    display: flex;
-    justify-content: center;
+    @include center-box;
   }
   &-side {
-    display: flex;
-    justify-content: space-between;
+    @include space-between-box;
     padding: 0 50px;
     &-left {
       display: flex;
       flex-direction: column;
-      button + button {
-        margin-left: 0;
-      }
-      button {
-        margin-bottom: 4px;
-      }
+      @include btn-margin;
     }
     &-right {
       display: flex;
       flex-direction: column;
-      button + button {
-        margin-left: 0;
-      }
-      button {
-        margin-bottom: 4px;
-      }
+      @include btn-margin;
     }
   }
   &-bottom {
-    display: flex;
-    justify-content: center;
+    @include center-box;
   }
 }

--- a/src/components/popper/PopperStyle.scss
+++ b/src/components/popper/PopperStyle.scss
@@ -1,0 +1,37 @@
+.popper-story {
+  padding: 50px;
+
+  &-top {
+    display: flex;
+    justify-content: center;
+  }
+  &-side {
+    display: flex;
+    justify-content: space-between;
+    padding: 0 50px;
+    &-left {
+      display: flex;
+      flex-direction: column;
+      button + button {
+        margin-left: 0;
+      }
+      button {
+        margin-bottom: 4px;
+      }
+    }
+    &-right {
+      display: flex;
+      flex-direction: column;
+      button + button {
+        margin-left: 0;
+      }
+      button {
+        margin-bottom: 4px;
+      }
+    }
+  }
+  &-bottom {
+    display: flex;
+    justify-content: center;
+  }
+}

--- a/src/components/popper/PopperStyle.scss
+++ b/src/components/popper/PopperStyle.scss
@@ -9,6 +9,14 @@
   }
 }
 
+.muop-popper {
+  display: none;
+  position: absolute;
+  will-change: transform;
+  top: 0;
+  left: 0;
+}
+
 .popper-story {
   padding: 50px;
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -63,3 +63,15 @@ $md: calc-width(6);
 $sm: calc-width(3);
 $x-sm: calc-width(2);
 $xx-sm: calc-width(1);
+
+@mixin center-box {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+@mixin space-between-box {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}


### PR DESCRIPTION
## 개요
> Popper Component 추가 (개별적으로도 쓰이고, 특히 드롭다운 메뉴로도 활용예정)

## 스크린샷
![image](https://user-images.githubusercontent.com/32199644/126635582-eb93ca1b-f943-4e5c-bebd-001f82bcbc40.png)

## 바꾼거
- Button.tsx : onClick Props의 event 파라미터를 optional에서 필수값으로 변경함

## 공유할만한거
- 이벤트 함수를 콜백함수 정의하면 JSX에서 쓰일때 보기 좋다
  - before 
```
const handleClick = (event: React.MouseEvent<HTMLButtonElement>, newPlacement: TPlacement) => { ... }
...
<Button onClick={(e) => handleClick(e, 'top')}>...</Button>
```
  - after
```
const handleClick = (newPlacement: TPlacement) => (event: React.MouseEvent<HTMLButtonElement>) => { ... }
...
<Button onClick={handleClick('top')}>...</Button>
...
```
- 타입스크립트에선 enum 함수를 쓰지말자 [참조사이트](https://engineering.linecorp.com/ko/blog/typescript-enum-tree-shaking/)
```
const TPlacement = {
  bottomStart: 'bottom-start',
  bottom: 'bottom',
  bottomEnd: 'bottom-end',
};
type TPlacement = typeof TPlacement[keyof typeof TPlacement];
```
  - 사용할때는 `TPlacement.bottom` 이런식으로 enum 처럼쓰임